### PR TITLE
Add stuff for GPG signing

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -55,6 +55,10 @@ export PATH="/opt/homebrew/opt/openssl@1.1/bin:$PATH"
 export PNPM_HOME="$HOME/Library/pnpm"
 export PATH="$PNPM_HOME:$PATH"
 
+# GPG
+export GPG_TTY=$(tty)
+gpgconf --launch gpg-agent
+
 autoload -U +X bashcompinit && bashcompinit
 complete -o nospace -C /opt/homebrew/bin/terraform terraform
 

--- a/Brewfile
+++ b/Brewfile
@@ -67,6 +67,7 @@ cask 'gitbutler'
 cask 'gitup'
 cask 'gog-galaxy'
 cask 'google-chrome'
+cask 'gpg-suite' # once installed, activate use-agent in `~/.gnupg/gpg.confg`
 cask 'grandperspective'
 cask 'handbrake'
 cask 'hazeover'

--- a/Brewfile
+++ b/Brewfile
@@ -14,6 +14,7 @@ brew 'grep'
 brew 'mackup'
 brew 'mas'
 brew 'openfortivpn'
+brew 'pinentry-mac'
 brew 'pkg-config' # https://github.com/driesvints/dotfiles/issues/20
 brew 'terraform'
 brew 'thefuck'


### PR DESCRIPTION
Not sure I want this…

Seems to be useful only in order to sign the commit/tag done by NPM when doing `npm version`, which should be circumvented either by automation (publish with CI pipeline, not with local machine) either by doing manually the bump (update of `package.json` + update of lock file using `npm install`).

Also, to check:
- https://github.com/driesvints/dotfiles/issues/86